### PR TITLE
Wrong inline class for radio input

### DIFF
--- a/src/components/BaseRadio.vue
+++ b/src/components/BaseRadio.vue
@@ -49,7 +49,7 @@ export default {
     },
     inlineClass() {
       if (this.inline) {
-        return `form-check-inline`;
+        return `custom-control-inline`;
       }
       return "";
     }


### PR DESCRIPTION
Hello,

When using the BaseRadio component with inline prop set to true, the radio buttons won't render inlined. I noticed this is because the wrong class was being set. The correct class should be 'custom-control-inline' instead of 'form-check-inline', since custom controls are being used.

Thanks.